### PR TITLE
Category highlighting

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -28,13 +28,13 @@ const renderExpenses = (expenses) => {
 
 
 // Highlight expenses that match the selected category
-$('#category-highlight').on('change', (e) => {
+$('#highlight-category').on('change', (e) => {
 
   // Remove any pre-existing highlights
   $('#expenses-data').find('tr').removeClass('highlighted');
 
   // Get the currently selected category and find matching table rows
-  const selectedCategory = $(e.currentTarget).val();
+  const selectedCategory = $(e.currentTarget).val().toLowerCase();
   const matches = $('#expenses-data').find(`tr.${selectedCategory}`);
 
   // Add a highlight class to all matches

--- a/public/style.css
+++ b/public/style.css
@@ -93,5 +93,5 @@ table td {
 }
 
 .highlighted {
-  background-color: #666;
+  background-color: yellow;
 }


### PR DESCRIPTION
We fixed the highlighting for categories selected in the expenses table.  It now highlights the corresponding expenses by category when selected.  The errors were caused by the CSS not coloring the background a yellow color, and the wrong ID being selected for the event listener.  Along with this the selections had a capital letter while classnames did not so the selection is now passed through in lowercase.